### PR TITLE
SQLFluff remove rule RF04

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,3 +1,3 @@
 [sqlfluff]
 dialect = snowflake
-exclude_rules = LT05, ST06, RF04
+exclude_rules = LT05, ST06


### PR DESCRIPTION
It may be reintroduced in the future.

Snowflake has, among other things, the following reserved words: `account`, `organization`, and `values`. These may be needed in some of your exposing models. However, since this is a template, I'll keep the code as strict as possible.

[SQLFLuff rule-RF04](https://docs.sqlfluff.com/en/stable/reference/rules.html#rule-RF04)